### PR TITLE
Bump urllib3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -115,7 +115,7 @@ triton==3.1.0
 typing-inspect==0.9.0
 typing_extensions==4.12.2
 tzdata==2024.2
-urllib3==2.3.0
+urllib3==2.5.0
 watchdog==6.0.0
 xxhash==3.5.0
 yarl==1.18.3


### PR DESCRIPTION
Changin urllib3 version to 2.5.0 due to CVE-2025-50182